### PR TITLE
Refactor actor stats for ease of use

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -109,7 +109,7 @@ description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.0"
+version = "0.13.1"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
@@ -264,7 +264,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "bc6c7c494879ef33442a4e311e81e6bb4860b048072292141fedd29baf622c58"
+content-hash = "aa7449f8355322b8ddeabf61b454788ed313a5ac8ff814edec0f6e460349a3ad"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -279,7 +279,7 @@ importlib-metadata = ["aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25
 mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"]
 mock = ["83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3", "d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"]
 more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
-pluggy = ["0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6", "fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"]
+pluggy = ["15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0", "966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"]
 pprint = ["c0fa22d1462351671ca098e9779bb26a23880011e93eea5f199a150ee7b92a16"]
 prompt-toolkit = ["7281b5199235adaef6980942840c43753e4ab20dfe41338da634fb41c194f9d8", "82c7f8e07d7a0411ff5367a5a8ff520f0112b9179f3e599ee8ad2ad9b943d911", "cc66413b1b4b17021675d9f2d15d57e640b06ddfd99bb724c73484126d22622f"]
 py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ tabulate = "^0.8.6"
 pprint = "^0.1.0"
 PyInquirer = "^1.0"
 tinydb = "^3.15"
+pyinquirer = "^1.0.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/squirrel_maze/resources/actor.py
+++ b/squirrel_maze/resources/actor.py
@@ -10,22 +10,40 @@ EQUIPMENT_DEFAULTS = {
     'accessory': 0
 }
 
+STAT_DEFAULTS = {
+        'max_str': 10,
+        'max_dex': 10,
+        'max_sta': 10,
+        'max_wil': 10,
+        'max_hp': 10
+}
+
 
 class Actor:
-    def __init__(self, actor_id=0, pc_type="npc", affiliation="friendly", name="unknown", level=0, max_hp=0,
-                 max_str=0, max_dex=0, max_sta=0, max_wil=0, equipment=EQUIPMENT_DEFAULTS):
+    def __init__(self, actor_id=0, level=1, pc_type="npc", affiliation="friendly", name="unknown", stats=STAT_DEFAULTS,
+                 equipment=EQUIPMENT_DEFAULTS):
+        self.initialize_stats()
+        self.set_stats(stats)
+        self.max_crit_hit_chance = 10
+        self.max_crit_fail_chance = 1
+        self.restore_all_stats_to_max()
+
         self.actor_id = actor_id
         self.pc_type = pc_type
         self.affiliation = affiliation
         self.name = name
         self.level = level
         self.status = "normal"
-        self.max_crit_hit_chance = 10
-        self.cur_crit_hit_chance = 10
-        self.max_crit_fail_chance = 1
-        self.cur_crit_fail_chance = 1
-        self.set_stats(max_hp, max_str, max_dex, max_sta, max_wil)
         self.set_equipment(equipment)
+
+    def initialize_stats(self):
+        self.max_hp = 0
+        self.max_str = 0
+        self.max_dex = 0
+        self.max_sta = 0
+        self.max_wil = 0
+        self.max_crit_hit_chance = 10
+        self.max_crit_fail_chance = 1
 
     def set_equipment(self, equipment):
         self.equipment = {
@@ -42,17 +60,27 @@ class Actor:
     def get_weapon(self):
         return self.equipment['weapon']
 
-    def set_stats(self, max_hp, max_str, max_dex, max_sta, max_wil):
-        self.max_hp = max_hp
-        self.max_str = max_str
-        self.max_dex = max_dex
-        self.max_sta = max_sta
-        self.max_wil = max_wil
-        self.cur_hp = max_hp
-        self.cur_str = max_str
-        self.cur_dex = max_dex
-        self.cur_sta = max_sta
-        self.cur_wil = max_wil
+    def set_stats(self, stats):
+        if 'max_hp' in stats.keys():
+            self.max_hp = stats['max_hp']
+        else:
+            self.max_hp = 10
+        if 'max_str' in stats.keys():
+            self.max_str = stats['max_str']
+        else:
+            self.max_str = 10
+        if 'max_dex' in stats.keys():
+            self.max_dex = stats['max_dex']
+        else:
+            self.max_dex = 10
+        if 'max_sta' in stats.keys():
+            self.max_sta = stats['max_sta']
+        else:
+            self.max_sta = 10
+        if 'max_wil' in stats.keys():
+            self.max_wil = stats['max_wil']
+        else:
+            self.max_wil = 10
 
     def print_char_sheet(self):
         print(
@@ -77,6 +105,9 @@ class Actor:
 
     def modify_stat(self, stat, value):
         self.__setattr__(stat, self.__getattribute__(stat) + value)
+
+    def set_stat(self, stat, value):
+        self.__setattr__(stat, self.__getattribute__(stat))
 
     def change_attribute(self, stat, value):
         self.__setattr__(stat, value)

--- a/squirrel_maze/resources/db_helpers.py
+++ b/squirrel_maze/resources/db_helpers.py
@@ -22,9 +22,9 @@ class Database:
 
     def get_actor(self, actor_id, pc_type='npc', affiliation='friendly'):
         db_actor = self.get_actor_by_id(actor_id)
-        return sm_actor.Actor(name=db_actor['name'], level=db_actor['attributes']['level'],
-                              max_str=db_actor['attributes']['str'], max_dex=db_actor['attributes']['dex'],
-                              max_sta=db_actor['attributes']['sta'], max_hp=db_actor['attributes']['hp'],
+        return sm_actor.Actor(name=db_actor['name'], stats={'level': db_actor['attributes']['level'],
+                              'max_str': db_actor['attributes']['str'], 'max_dex': db_actor['attributes']['dex'],
+                              'max_sta': db_actor['attributes']['sta'], 'max_hp': db_actor['attributes']['hp']},
                               pc_type=pc_type, affiliation=affiliation, actor_id=actor_id)
 
     def get_actor_by_id(self, actor_id):

--- a/test/unit/helpers.py
+++ b/test/unit/helpers.py
@@ -3,24 +3,25 @@ from squirrel_maze.resources import weapon
 
 
 def get_single_actor():
-    return actor.Actor(actor_id=0, name='ham', pc_type='pc', affiliation='friendly', level=1, max_hp=10, max_str=10,
-                       max_dex=10, max_sta=10, equipment={'weapon': 1, 'body': 0, 'head': 0, 'arm': 0, 'accessory': 0})
+    return actor.Actor(actor_id=0, name='ham', level=1, pc_type='pc', affiliation='friendly',
+                       stats={'max_hp': 10, 'max_str': 10, 'max_dex': 10, 'max_sta': 10},
+                       equipment={'weapon': 1, 'body': 0, 'head': 0, 'arm': 0, 'accessory': 0})
 
 
 def get_multiple_actors():
     actors = []
-    actors.append(actor.Actor(actor_id=0, name='ham', pc_type='pc', affiliation='friendly', level=1, max_hp=10,
-                  max_str=10, max_dex=12, max_sta=10))
-    actors.append(actor.Actor(actor_id=1, name='spam', pc_type='pc', affiliation='friendly', level=1, max_hp=10,
-                  max_str=10, max_dex=10, max_sta=10))
-    actors.append(actor.Actor(actor_id=2, name='eggs', pc_type='pc', affiliation='friendly', level=1, max_hp=5,
-                  max_str=5, max_dex=5, max_sta=5))
-    actors.append(actor.Actor(actor_id=3, name='foo', pc_type='npc', affiliation='friendly', level=1, max_hp=6,
-                  max_str=6, max_dex=6, max_sta=6))
-    actors.append(actor.Actor(actor_id=4, name='bar', pc_type='npc', affiliation='unfriendly', level=1, max_hp=6,
-                  max_str=6, max_dex=6, max_sta=6))
-    actors.append(actor.Actor(actor_id=5, name='baz', pc_type='npc', affiliation='unfriendly', level=1, max_hp=2,
-                  max_str=2, max_dex=2, max_sta=2))
+    actors.append(actor.Actor(actor_id=0, name='ham', pc_type='pc', affiliation='friendly',
+                  stats={'max_hp': 10, 'max_str': 10, 'max_dex': 12, 'max_sta': 10}))
+    actors.append(actor.Actor(actor_id=1, name='spam', pc_type='pc', affiliation='friendly',
+                  stats={'max_hp': 10, 'max_str': 10, 'max_dex': 10, 'max_sta': 10}))
+    actors.append(actor.Actor(actor_id=2, name='eggs', pc_type='pc', affiliation='friendly',
+                  stats={'max_hp': 5, 'max_str': 5, 'max_dex': 5, 'max_sta': 5}))
+    actors.append(actor.Actor(actor_id=3, name='foo', pc_type='npc', affiliation='friendly',
+                  stats={'max_hp': 6, 'max_str': 6, 'max_dex': 6, 'max_sta': 6}))
+    actors.append(actor.Actor(actor_id=4, name='bar', pc_type='npc', affiliation='unfriendly',
+                  stats={'max_hp': 6, 'max_str': 6, 'max_dex': 6, 'max_sta': 6}))
+    actors.append(actor.Actor(actor_id=5, name='baz', pc_type='npc', affiliation='unfriendly',
+                  stats={'max_hp': 2, 'max_str': 2, 'max_dex': 2, 'max_sta': 2}))
     return actors
 
 

--- a/test/unit/test_action.py
+++ b/test/unit/test_action.py
@@ -8,7 +8,7 @@ from squirrel_maze.resources import actor
 @patch('squirrel_maze.resources.actor.Actor.get_def_value', return_value=15, autospec=True)
 def test_fight(mock_atk, mock_def):
     source_actor = actor.Actor()
-    target_actor = actor.Actor(max_hp=20)
+    target_actor = actor.Actor(stats={'max_hp': 20})
     action.fight(source_actor, target_actor)
     assert target_actor.cur_hp == 11
 
@@ -17,7 +17,7 @@ def test_fight(mock_atk, mock_def):
 @patch('squirrel_maze.resources.actor.Actor.get_def_value', return_value=15, autospec=True)
 def test_fight_min_damage(mock_atk, mock_def):
     source_actor = actor.Actor()
-    target_actor = actor.Actor(max_hp=20)
+    target_actor = actor.Actor(stats={'max_hp': 20})
     action.fight(source_actor, target_actor)
     assert target_actor.cur_hp == 19
 
@@ -25,7 +25,7 @@ def test_fight_min_damage(mock_atk, mock_def):
 @patch('squirrel_maze.resources.action.fight')
 def test_fight_all(mock_fight):
     source_actor = actor.Actor()
-    target = actor.Actor(max_hp=20)
+    target = actor.Actor(stats={'max_hp': 20})
     targets = [
         target,
         target,
@@ -42,8 +42,8 @@ def test_fight_all(mock_fight):
 @patch('squirrel_maze.resources.action.helpers.random.randint', return_value=2, autospec=True)
 @patch('squirrel_maze.resources.action.helpers.calc_magic_defense', return_value=-1, autospec=True)
 def test_fire_bolt(mock_rand, mock_md):
-    source_actor = actor.Actor(level=10, max_wil=5)
-    target_actor = actor.Actor(level=10, max_wil=6)
+    source_actor = actor.Actor(level=10, stats={'max_wil': 5})
+    target_actor = actor.Actor(level=10, stats={'max_wil': 6})
 
     dmg = action.fire_bolt(source_actor, target_actor)
     assert dmg[0]['element'] == "fire"

--- a/test/unit/test_actor.py
+++ b/test/unit/test_actor.py
@@ -20,13 +20,21 @@ def test_initialize():
 def test_set_stats():
     actor_ham = test_helpers.get_single_actor()
 
-    actor_ham.set_stats(1, 2, 3, 4, 5)
+    test_stats = {
+        'max_hp': 1,
+        'max_str': 2,
+        'max_dex': 3,
+        'max_sta': 4,
+        'max_wil': 5
+    }
+    actor_ham.set_stats(test_stats)
 
     assert actor_ham.max_hp == 1
     assert actor_ham.max_str == 2
     assert actor_ham.max_dex == 3
     assert actor_ham.max_sta == 4
     assert actor_ham.max_wil == 5
+    assert actor_ham.level == 1
 
 
 def test_modify_stat():
@@ -80,15 +88,13 @@ def test_restore_all_stats_to_max(mock_restore):
 @patch('squirrel_maze.resources.actor.helpers.random.randint', return_value=6, autospec=True)
 def test_get_atk_value(mock_rand):
     actor_ham = test_helpers.get_single_actor()
-    atk_val = actor_ham.get_atk_value()
-    assert atk_val == 27
+    assert actor_ham.get_atk_value() == 27
 
 
 @patch('squirrel_maze.resources.actor.helpers.random.randint', return_value=6, autospec=True)
 def test_get_def_value(mock_rand):
     actor_ham = test_helpers.get_single_actor()
-    atk_val = actor_ham.get_def_value()
-    assert atk_val == 26
+    assert actor_ham.get_def_value() == 26
 
 
 def test_get_friendly_actors():

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -55,28 +55,32 @@ def test_get_stat_list():
 
 
 def test_calc_magic_defense():
-    source_actor = actor.Actor(level=10, max_wil=5)
-    target_actor = actor.Actor(level=10, max_wil=8)
+    source_actor = actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0})
+    target_actor = actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 8, 'max_hp': 0})
 
-    md = helpers.calc_magic_defense(source_actor, target_actor)
-
-    assert md == -3
+    assert helpers.calc_magic_defense(source_actor, target_actor) == -3
 
 
 def test_any_members_alive():
     actors = []
-    actors.append(actor.Actor(max_hp=10, pc_type='pc'))
-    actors.append(actor.Actor(max_hp=0, pc_type='pc'))
-    actors.append(actor.Actor(max_hp=0, pc_type='npc'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 10},
+                  pc_type='pc'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='pc'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='npc'))
 
     assert helpers.any_members_alive(actors, 'pc') is True
 
 
 def test_any_members_alive_false():
     actors = []
-    actors.append(actor.Actor(max_hp=0, pc_type='pc'))
-    actors.append(actor.Actor(max_hp=0, pc_type='pc'))
-    actors.append(actor.Actor(max_hp=0, pc_type='npc'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='pc'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='pc'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 0, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='npc'))
 
     assert helpers.any_members_alive(actors, 'pc') is False
     assert helpers.any_members_alive(actors, 'npc') is False
@@ -84,20 +88,22 @@ def test_any_members_alive_false():
 
 def test_get_max_stat_from_actor_list():
     actors = []
-    actors.append(actor.Actor(name='foo', level=1, max_dex=10))
-    actors.append(actor.Actor(name='bar', level=2, max_dex=5))
-    actors.append(actor.Actor(name='baz', level=1, max_dex=15))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 10, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='pc', name='foo'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 5, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='pc', name='bar'))
+    actors.append(actor.Actor(stats={'level': 10, 'max_str': 0, 'max_dex': 15, 'max_sta': 0, 'max_wil': 5, 'max_hp': 0},
+                  pc_type='pc', name='bar'))
 
-    max_val = helpers.get_max_stat_from_actor_list(actors, 'cur_dex')
-    assert max_val == 15
+    assert helpers.get_max_stat_from_actor_list(actors, 'cur_dex') == 15
 
 
 def test_get_actor_list_by_stat():
     actors = []
-    actors.append(actor.Actor(name='foo', level=1, max_dex=10))
-    actors.append(actor.Actor(name='bar', level=2, max_dex=5))
-    actors.append(actor.Actor(name='baz', level=3, max_dex=15))
-    actors.append(actor.Actor(name='ham', level=1, max_dex=15))
+    actors.append(actor.Actor(name='foo', stats={'level': 1, 'max_dex': 10}))
+    actors.append(actor.Actor(name='bar', stats={'level': 2, 'max_dex': 5}))
+    actors.append(actor.Actor(name='baz', stats={'level': 3, 'max_dex': 15}))
+    actors.append(actor.Actor(name='ham', stats={'level': 1, 'max_dex': 15}))
 
     sorted_actors = helpers.get_actor_list_by_stat(actors, 'cur_dex', 'level')
 


### PR DESCRIPTION
When initializing an actor, each stat is no longer listed individually. They are listed together in a dictionary. If a subset is given, any missing will be set to 10. This is similar to how equipment is set.
Upgraded pyinquirer to latest version and added dev dependency of ipython.